### PR TITLE
feat: Support identity flags with POST request for edge-proxy

### DIFF
--- a/FlagsmithClient/build.gradle.kts
+++ b/FlagsmithClient/build.gradle.kts
@@ -153,7 +153,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.pomelofashion"
             artifactId = "flagsmith-kotlin-android-client"
-            version = "1.0.1"
+            version = "1.0.1.3"
             artifact("$buildDir/outputs/aar/FlagsmithClient-release.aar")
 
             pom {

--- a/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithApi.kt
+++ b/FlagsmithClient/src/main/java/com/flagsmith/internal/FlagsmithApi.kt
@@ -10,7 +10,7 @@ import com.github.kittinunf.fuel.util.FuelRouting
 import com.google.gson.Gson
 
 sealed class FlagsmithApi : FuelRouting {
-    class GetIdentityFlagsAndTraits(val identity: String) : FlagsmithApi()
+    class GetIdentityFlagsAndTraits(val identity: String, val traits: List<Trait>? = null) : FlagsmithApi()
     object GetFlags : FlagsmithApi()
     class SetTrait(val trait: Trait, val identity: String) : FlagsmithApi()
     class PostAnalytics(val eventMap: Map<String, Int?>) : FlagsmithApi()
@@ -38,6 +38,13 @@ sealed class FlagsmithApi : FuelRouting {
                 )
             )
             is PostAnalytics -> Gson().toJson(eventMap)
+            is GetIdentityFlagsAndTraits -> Gson().toJson(
+                mutableMapOf<String, Any>("identifier" to identity).apply {
+                    if (!traits.isNullOrEmpty()) {
+                        this += "traits" to traits
+                    }
+                }
+            )
             else -> null
         }
 
@@ -54,7 +61,7 @@ sealed class FlagsmithApi : FuelRouting {
 
     override val method: Method
         get() = when (this) {
-            is GetIdentityFlagsAndTraits -> Method.GET
+            is GetIdentityFlagsAndTraits -> Method.POST
             is GetFlags -> Method.GET
             is SetTrait -> Method.POST
             is PostAnalytics -> Method.POST

--- a/FlagsmithClient/src/test/java/com/flagsmith/SynchronousFlagsmith.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/SynchronousFlagsmith.kt
@@ -8,13 +8,13 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 suspend fun Flagsmith.hasFeatureFlagSync(forFeatureId: String, identity: String? = null): Result<Boolean>
-    = suspendCoroutine { cont -> this.hasFeatureFlag(forFeatureId, identity = identity) { cont.resume(it) } }
+    = suspendCoroutine { cont -> this.hasFeatureFlag(forFeatureId, identity = identity, traits = emptyList()) { cont.resume(it) } }
 
 suspend fun Flagsmith.getFeatureFlagsSync(identity: String? = null) : Result<List<Flag>>
-    = suspendCoroutine { cont -> this.getFeatureFlags(identity = identity) { cont.resume(it) } }
+    = suspendCoroutine { cont -> this.getFeatureFlags(identity = identity, traits = emptyList()) { cont.resume(it) } }
 
 suspend fun Flagsmith.getValueForFeatureSync(forFeatureId: String, identity: String? = null): Result<Any?>
-    = suspendCoroutine { cont -> this.getValueForFeature(forFeatureId, identity = identity) { cont.resume(it) } }
+    = suspendCoroutine { cont -> this.getValueForFeature(forFeatureId, identity = identity, traits = emptyList()) { cont.resume(it) } }
 
 suspend fun Flagsmith.getTraitsSync(identity: String): Result<List<Trait>>
     = suspendCoroutine { cont -> this.getTraits(identity) { cont.resume(it) } }

--- a/FlagsmithClient/src/test/java/com/flagsmith/TraitsTests.kt
+++ b/FlagsmithClient/src/test/java/com/flagsmith/TraitsTests.kt
@@ -3,6 +3,7 @@ package com.flagsmith
 import com.flagsmith.entities.Trait
 import com.flagsmith.mockResponses.MockEndpoint
 import com.flagsmith.mockResponses.mockResponseFor
+import com.google.gson.Gson
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -103,5 +104,14 @@ class TraitsTests {
                 result.getOrThrow().traits.find { trait -> trait.key == "favourite-colour" }?.value
             )
         }
+    }
+
+    @Test
+    fun testTraitToJson() {
+        val traits = listOf(
+            Trait(key = "key", value = "value")
+        )
+        val json = Gson().toJson(mapOf("traits" to traits))
+        assertEquals("{\"traits\":[{\"trait_key\":\"key\",\"trait_value\":\"value\"}]}", json)
     }
 }


### PR DESCRIPTION
### What problem does this PR solve?
Get identify flags with edge-proxy requires POST API call instead of GET and also requires all traits to be passed in the request body.


### How does this PR solve it?
Add support in the code and change request to this format only
